### PR TITLE
Add Vite 8 support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,10 +12,10 @@
         "@types/node": "^20.8.2",
         "prettier": "^3.0.3",
         "typescript": "^5.2.2",
-        "vite": "^5.0 || ^6.0 || ^7.0"
+        "vite": "^5.0 || ^6.0 || ^7.0 || ^8.0"
       },
       "peerDependencies": {
-        "vite": "^5.0 || ^6.0 || ^7.0"
+        "vite": "^5.0 || ^6.0 || ^7.0 || ^8.0"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {

--- a/package.json
+++ b/package.json
@@ -39,12 +39,12 @@
     "test:distribution:ts": "cd tests/distribution/typescript/ && npm install && npm run build && npm run typecheck"
   },
   "peerDependencies": {
-    "vite": "^5.0 || ^6.0 || ^7.0"
+    "vite": "^5.0 || ^6.0 || ^7.0 || ^8.0"
   },
   "devDependencies": {
     "@types/node": "^20.8.2",
     "prettier": "^3.0.3",
     "typescript": "^5.2.2",
-    "vite": "^5.0 || ^6.0 || ^7.0"
+    "vite": "^5.0 || ^6.0 || ^7.0 || ^8.0"
   }
 }


### PR DESCRIPTION
## Summary

* Add `^8.0` to `peerDependencies` and `devDependencies` version range

Vite 8 replaces Rollup with Rolldown as its bundler but keeps the plugin API fully compatible. All APIs used by this plugin (`configureServer` hook, `transform` hook, `createLogger`, `server.origin`, `server.https`) remain unchanged in Vite 8.

The plugin builds and passes lint without any code changes — only the version range needs to be extended.

## Test plan

* `npm run build` — compiles successfully with Vite 8 types
* `npm run lint` — passes without issues
* `npm run test:distribution` — all three distribution tests pass (CJS, ESM, TypeScript)